### PR TITLE
backslash on line 156 removed

### DIFF
--- a/dnsClient.py
+++ b/dnsClient.py
@@ -153,7 +153,7 @@ def dns_query(type, name, server):
         if type == ?????: # Lookup Type value
             # A record (IPv4 address)
             ipv4 = socket.inet_ntop(socket.AF_INET, rdata)
-            print(f'{name} has IPv4 address {ipv4}')\
+            print(f'{name} has IPv4 address {ipv4}')
             return ipv4
         elif type == ?????: # Lookup Type value
             # AAAA record (IPv6 address)


### PR DESCRIPTION
Greetings,
I received a syntax error testing the dnsClient.py locally this evening.

<img width="846" height="109" alt="image" src="https://github.com/user-attachments/assets/7e63fff0-5da4-4c48-8e4e-81cbcf207d7d" />

And, afterwards noticed a conspicuous `\` at line 156. Once I removed that single character the file exec. as intended.

<img width="848" height="178" alt="image" src="https://github.com/user-attachments/assets/7ed2851e-f036-4796-a3f6-19ea65980daa" />

Minor edit, and hopefully not to be disregarded. 
( A *linter* may not always be supported on student IDE. )